### PR TITLE
Fixed parse_all_reviews to handle non-sequential movie_ids

### DIFF
--- a/core/database/db_services.py
+++ b/core/database/db_services.py
@@ -1,5 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, load_only
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy import func, update
 
@@ -90,6 +90,13 @@ class DatabaseServices(object):
             self.get_session()
 
         return self.session.query(func.count(Movie.movie_id)).scalar()
+
+    def get_all_movie_ids(self):
+        """ Fetches all movie_ids from the DB """
+        if self.session is None:
+            self.get_session()
+
+        return self.session.query(Movie).options(load_only("movie_id"))
 
     def add_review_full_text(self, movie_id, full_text):
         ''' Updates the DB entry with the full review text '''

--- a/main.py
+++ b/main.py
@@ -235,14 +235,15 @@ def generate_zeroes(offset, million=False, billion=False):
 
 def parse_all_reviews():
     database = DatabaseServices(DATABASE_NAME)
-    num_movies = database.get_num_movies()
+    movies = database.get_all_movie_ids()
 
-    for i in range(1, num_movies+1):
-        parsed_review = fetch_items_from_review(i)
+    for movie in movies:
+        movie_id = movie.movie_id
+        parsed_review = fetch_items_from_review(movie_id)
         
         if parsed_review is not None:
             item_csv = ",".join(parsed_review)
-            database.add_item_csv(i, item_csv)
+            database.add_item_csv(movie_id, item_csv)
 
 
 def fetch_items_from_review(review_id=1):


### PR DESCRIPTION
Altered parse_all_reviews to handle non-sequential movie_ids
Ran parse_all_reviews on DB.
Ran DELETE FROM movies WHERE full_review = "" (some entries had no review)